### PR TITLE
feat(issue100v4): Add modal with proper context views

### DIFF
--- a/components/Day.tsx
+++ b/components/Day.tsx
@@ -38,8 +38,12 @@ function Day(): JSX.Element {
       genre,
       releasedDate,
     } = data;
+
     return (
-      <LayoutDrawer placement="bottom" isRoute>
+      <LayoutDrawer
+        placement="bottom"
+        isOpen={view === "day" || view === "edit"}
+      >
         {view === "edit" ? (
           <Edit />
         ) : (

--- a/components/LayoutDrawer.tsx
+++ b/components/LayoutDrawer.tsx
@@ -19,15 +19,14 @@ import { useSwipeable } from "react-swipeable";
 function LayoutDrawer({
   children,
   refHook,
-  isRoute,
   placement = "right",
+  isOpen,
   ...rest
 }: PropsWithChildren<unknown> & {
   refHook?: RefObject<HTMLInputElement> | undefined;
-  isRoute?: boolean;
+  isOpen: DrawerProps["isOpen"];
   placement?: DrawerProps["placement"];
 }): JSX.Element {
-  const router = useRouter();
   const dispatch = useMDDispatch();
   const handlers = useSwipeable({
     onSwipedRight: () => onClose(),
@@ -36,7 +35,7 @@ function LayoutDrawer({
   return (
     <Drawer
       onClose={onClose}
-      isOpen={true}
+      isOpen={isOpen}
       size="full"
       placement={placement}
       initialFocusRef={refHook}
@@ -68,9 +67,6 @@ function LayoutDrawer({
 
   function onClose() {
     dispatch({ type: "state", payload: { key: "view", value: "" } });
-    if (isRoute) {
-      router.push("/home");
-    }
   }
 }
 

--- a/components/Log.tsx
+++ b/components/Log.tsx
@@ -13,8 +13,7 @@ import LayoutDrawer from "./LayoutDrawer";
 import LogFields from "./LogFields";
 
 function Log(): JSX.Element {
-  // const { selected } = useContext(ContextState);
-  const { selected, isSaving } = useMDState();
+  const { selected, isSaving, view } = useMDState();
   const mdDispatch = useMDDispatch();
   const { user } = useAuth();
   const router = useRouter();
@@ -144,7 +143,7 @@ function Log(): JSX.Element {
   }
 
   return (
-    <LayoutDrawer>
+    <LayoutDrawer isOpen={view === "log"}>
       {isLoading || isSaving ? (
         <Center minH="40vh">
           <Spinner />

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -17,7 +17,7 @@ import dayjs from "dayjs";
 import React, { useRef, useState } from "react";
 import useSWR from "swr";
 import type { MediaSelected, MediaTypes } from "../config/mediaTypes";
-import { useMDDispatch } from "../config/store";
+import { useMDDispatch, useMDState } from "../config/store";
 import { fetcher } from "../utils/helpers";
 import useDebounce from "../utils/useDebounce";
 import AlbumIcon from "./Icons/AlbumIcon";
@@ -31,6 +31,7 @@ function Search(): JSX.Element {
   const [currTv, setCurrTv] = useState(3);
   const [currAlbum, setCurrAlbum] = useState(3);
   const dispatch = useMDDispatch();
+  const { view } = useMDState();
   const refInput = useRef<HTMLInputElement>(null);
 
   const bouncedSearch = useDebounce(search, 500);
@@ -70,7 +71,7 @@ function Search(): JSX.Element {
 
   return (
     <Modal
-      isOpen={true}
+      isOpen={view === "search"}
       onClose={() =>
         dispatch({ type: "state", payload: { key: "view", value: "" } })
       }

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -2,6 +2,7 @@ import { Flex, Grid, Spinner } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import React from "react";
 import Day from "../components/Day";
+import Edit from "../components/Edit";
 import Header from "../components/Header";
 import LogoIcon from "../components/Icons/LogoIcon";
 import Layout from "../components/Layout";
@@ -32,9 +33,9 @@ function Home(): JSX.Element {
         <>
           <Header />
           <MediaDiary />
-          {view === "search" && <Search />}
-          {view === "log" && <Log />}
-          {(view === "day" || view === "edit") && <Day />}
+          <Search />
+          <Log />
+          <Day />
         </>
       )}
     </Layout>


### PR DESCRIPTION
## Solution
- Add Context `views` for modals instead of relying on booleans to open the modal/drawers
- This would provide a _better_(?) experience in safari. Have to check

closes #100 