### PR TITLE
migration(173): Add poster Url and mediaId formatting

### DIFF
--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -5,6 +5,7 @@ import { useMDDispatch, useMDState } from "../config/store";
 import type { MediaSelected } from "../config/types";
 import type { MDbMovie, MDbTV } from "../config/typesMDb";
 import type { SpotifyAlbum, SpotifyArtist } from "../config/typesSpotify";
+import { parsePosterUrl } from "../utils/helpers";
 import useDataFetch from "../utils/useDataFetch";
 import InfoBody from "./info/InfoBody";
 import InfoHeader from "./info/InfoHeader";
@@ -76,7 +77,7 @@ function InfoSelected({ item }: { item: MediaSelected }): JSX.Element {
             episodes: seasonItem.episode_count,
             poster:
               castItem.poster_path !== null
-                ? `https://image.tmdb.org/t/p/w500${castItem.poster_path}`
+                ? parsePosterUrl(castItem.poster_path, item.type)
                 : "",
             releasedDate: dayjs(seasonItem.air_date).toISOString(),
           };

--- a/src/components/Log.tsx
+++ b/src/components/Log.tsx
@@ -10,6 +10,7 @@ import useFuegoUser from "../interfaces/useFuegoUser";
 import InfoHeader from "./info/InfoHeader";
 import InfoFields from "./info/InfoFields";
 import MdSpinner from "./md/MdSpinner";
+import { createPosterURL, parsePosterUrl } from "../utils/helpers";
 
 function Log(): JSX.Element {
   const mdDispatch = useMDDispatch();
@@ -34,13 +35,14 @@ function Log(): JSX.Element {
       if (
         selected &&
         selected.seasons &&
+        selected.seasons[0].poster_path &&
         selected.seasons[0].poster_path !== null
       ) {
         mdDispatch({
           type: "selected",
           payload: {
             ...selected,
-            poster: `https://image.tmdb.org/t/p/w500${selected.seasons[0].poster_path}`,
+            poster: parsePosterUrl(selected.seasons[0].poster_path, "tv"),
           },
         });
         initSeason.current = false;

--- a/src/components/MediaDiary.tsx
+++ b/src/components/MediaDiary.tsx
@@ -22,6 +22,7 @@ import type {
   FuegoValidatedUser,
 } from "../config/types";
 import { fuegoDiaryGet } from "../interfaces/fuegoMDActions";
+import { createPosterURL } from "../utils/helpers";
 import AlbumIcon from "./icons/AlbumIcon";
 import FilmIcon from "./icons/FilmIcon";
 import LogoIcon from "./icons/LogoIcon";
@@ -199,7 +200,7 @@ function MediaDiary({ user }: { user: FuegoValidatedUser }): JSX.Element {
                       </Box>
                       <Box>
                         <Image
-                          src={poster}
+                          src={createPosterURL(poster, type)}
                           ignoreFallback
                           borderRadius="5px"
                           border="1px solid"

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,7 +12,7 @@ import type {
   SpotifySearch,
   SpotifySearchResult,
 } from "../config/typesSearch";
-import { fetcher } from "../utils/helpers";
+import { fetcher, parsePosterUrl } from "../utils/helpers";
 import { spotifyFetch } from "../utils/helperSpotify";
 import useDebounce from "../utils/useDebounce";
 import AlbumIcon from "./icons/AlbumIcon";
@@ -223,7 +223,7 @@ function Search({
       const castItem = item as SpotifySearchResult;
       return {
         mediaId: castItem.id,
-        poster: castItem.images[0].url,
+        poster: parsePosterUrl(castItem.images[0].url, type),
         title: castItem.name,
         releasedDate: dayjs(castItem.release_date).toISOString(),
         artist: castItem.artists[0].name,
@@ -244,7 +244,9 @@ function Search({
       }
       return {
         mediaId: castItem.id.toString(),
-        poster: `https://image.tmdb.org/t/p/w500${castItem.poster_path}`,
+        poster: castItem.poster_path
+          ? parsePosterUrl(castItem.poster_path, type as MediaType)
+          : "",
         title:
           type === "movie"
             ? castItem.title ?? ""

--- a/src/components/chart/ChartTop.tsx
+++ b/src/components/chart/ChartTop.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import Rating from "react-rating";
 import { useMDDispatch } from "../../config/store";
 import type { DiaryAddWithId } from "../../config/types";
+import { createPosterURL } from "../../utils/helpers";
 import StarEmptyIcon from "../icons/StartEmptyIcon";
 
 function ChartTop({ list }: { list: DiaryAddWithId[] }): JSX.Element {
@@ -33,7 +34,7 @@ function ChartTop({ list }: { list: DiaryAddWithId[] }): JSX.Element {
             alignItems="flex-end"
           >
             <Image
-              src={e.poster}
+              src={createPosterURL(e.poster, e.type)}
               borderRadius="5px"
               border="1px solid"
               borderColor="gray.300"

--- a/src/components/content/ContentMDb.tsx
+++ b/src/components/content/ContentMDb.tsx
@@ -7,6 +7,7 @@ import {
   Image,
 } from "@chakra-ui/react";
 import React from "react";
+import { MDB_IMGURL } from "../../config/contants";
 import type { MediaType } from "../../config/types";
 import type { MDbMovie, MDbTV } from "../../config/typesMDb";
 
@@ -61,9 +62,7 @@ function ContentMDb({
                   key={e.name}
                 >
                   {e.profile_path !== null && (
-                    <Image
-                      src={`https://image.tmdb.org/t/p/w200${e.profile_path}`}
-                    />
+                    <Image src={`${MDB_IMGURL}w200${e.profile_path}`} />
                   )}
                   <Box px={3} py={3}>
                     <Text fontWeight="bold" isTruncated>

--- a/src/components/info/InfoFields.tsx
+++ b/src/components/info/InfoFields.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../../config/types";
 import { MEDIA_LOGGED_BEFORE } from "../../config/contants";
 import { useMDDispatch } from "../../config/store";
+import { parsePosterUrl } from "../../utils/helpers";
 
 function InfoFields({
   dispatch,
@@ -134,14 +135,16 @@ function InfoFields({
                         (e) =>
                           e.season_number === parseInt(valueChange.target.value)
                       );
+                      const currentSeason = item.seasons[seasonIndex];
                       return mdDispatch({
                         type: "selected",
                         payload: {
                           ...item,
-                          season: item.seasons[seasonIndex].season_number,
+                          season: currentSeason.season_number,
                           poster:
-                            item.seasons[seasonIndex].poster_path !== null
-                              ? `https://image.tmdb.org/t/p/w500${item.seasons[seasonIndex].poster_path}`
+                            currentSeason.poster_path &&
+                            currentSeason.poster_path !== null
+                              ? parsePosterUrl(currentSeason.poster_path, "tv")
                               : item.poster,
                         },
                       });

--- a/src/components/info/InfoHeader.tsx
+++ b/src/components/info/InfoHeader.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import Rating from "react-rating";
 import { useMDDispatch, useMDState } from "../../config/store";
 import type { DiaryAdd, MediaSelected } from "../../config/types";
+import { createPosterURL } from "../../utils/helpers";
 import StarEmptyIcon from "../icons/StartEmptyIcon";
 
 interface Props {
@@ -68,7 +69,7 @@ function InfoHeader({
       >
         <Box ml="auto">
           <Image
-            src={poster}
+            src={createPosterURL(poster, type)}
             w="13rem"
             h={type === "album" ? "13rem" : "20rem"}
             borderRadius="5px"

--- a/src/config/contants.ts
+++ b/src/config/contants.ts
@@ -7,3 +7,7 @@ export const MEDIA_LOGGED_BEFORE: { [key in MediaType]: string } = {
   movie: "I've watched this before?",
   tv: "I've watched this before?",
 };
+
+export const MDB_IMGURL = "https://image.tmdb.org/t/p/";
+
+export const SPOTIFY_IMGURL = "https://i.scdn.co/image/";

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { MDB_IMGURL, SPOTIFY_IMGURL } from "../config/contants";
 import type { MediaTypesArr, MediaTypes, MediaType } from "../config/types";
 
 export async function fetcher<T>(key: string): Promise<T> {
@@ -36,4 +37,31 @@ export function createMediaTypes(mediaTypesArr: MediaTypesArr): MediaTypes {
     tv: mediaTypesArr.includes("tv") ? true : false,
     album: mediaTypesArr.includes("album") ? true : false,
   };
+}
+
+/** We only save the ID for poster Urls and thus we need to create the full Url */
+export function createPosterURL(
+  url: string,
+  type: MediaType,
+  width?: number
+): string {
+  if (type === "album") {
+    return `${SPOTIFY_IMGURL}${url}`;
+  } else {
+    if (width) {
+      return `${MDB_IMGURL}w${width}/${url}.jpg`;
+    }
+    return `${MDB_IMGURL}w500/${url}.jpg`;
+  }
+}
+
+/** We don't want to save the full URL to Fuego, rather just save the ID  */
+export function parsePosterUrl(url: string, type: MediaType): string {
+  if (type === "album") {
+    const item = url.split("/");
+    return item[item.length - 1];
+  } else {
+    const item = url.replace(".jpg", "").split("/");
+    return item[item.length - 1];
+  }
 }

--- a/src/utils/useDataFetch.tsx
+++ b/src/utils/useDataFetch.tsx
@@ -31,9 +31,7 @@ function useDataFetch({
   let returnKey = null;
   if (firstId) {
     if (type === "tv") {
-      // TODO: remove this after database migration
-      const idArr = firstId.split("_");
-      returnKey = getTVUrl(idArr[0], season);
+      returnKey = getTVUrl(firstId, season);
     } else if (type === "movie") {
       returnKey = getMovieUrl(firstId);
     } else if (type === "album" && secondId) {


### PR DESCRIPTION
## Solution
- Putting all of the poster Url as a constant url to manipulate the size of the width
- Removed the secondary Id from being using in mediaId

closes #173 