### PR TITLE
bug: Seasons wasnt finding the right season

### DIFF
--- a/src/components/Log/Log.tsx
+++ b/src/components/Log/Log.tsx
@@ -43,23 +43,27 @@ export default function Log(): JSX.Element {
   // // This is temporary because I think we should maybe let the user select IF they want to add a season
   // // They could also not want to select a season and just add the show.
   useEffect(() => {
-    if (initSeason.current) {
+    if (initSeason.current && selected?.seasons) {
+      const seasonIndex = selected?.seasons.findIndex(
+        (e) => e.season_number === 1
+      );
+      const selectedSeason = selected?.seasons[seasonIndex];
       if (
-        selected?.seasons &&
-        selected?.seasons[0].poster_path &&
-        selected?.seasons[0].poster_path !== null
+        selectedSeason &&
+        selectedSeason.poster_path &&
+        selectedSeason.poster_path !== null
       ) {
         mdDispatch({
           type: "selectedReplace",
           payload: {
             ...selected,
-            season: selected?.seasons[0].season_number,
-            episodes: selected?.seasons[0].episode_count,
-            poster: parsePosterUrl(selected?.seasons[0].poster_path, "tv"),
+            season: selectedSeason.season_number,
+            episodes: selectedSeason.episode_count,
+            poster: parsePosterUrl(selectedSeason.poster_path, "tv"),
           },
         });
-        initSeason.current = false;
       }
+      initSeason.current = false;
     }
   }, [selected, mdDispatch]);
 

--- a/src/components/Media/MediaTV.tsx
+++ b/src/components/Media/MediaTV.tsx
@@ -81,10 +81,12 @@ export default function MediaTV({
       credits.crew &&
       credits.crew.find((e) => e.job === "Director")?.name) ??
     artist;
-
+  const seasonIndex = seasons?.findIndex(
+    (e) => e.season_number === seasonInfo?.season
+  );
   const mediaDate =
-    seasonInfo?.season && seasonInfo.season !== -1 && seasons
-      ? seasons[seasonInfo.season].air_date
+    seasons && seasonIndex && seasons[seasonIndex]
+      ? seasons[seasonIndex].air_date
       : releasedDate ?? first_air_date;
 
   const showInfo = !edit && !logRating;


### PR DESCRIPTION
## Solution
- TV Seasons wasn't working as intended because the `season_number` that was passing wasn't correctly matching the index number of the `seasons` gathered from the API