### PR TITLE
feat: Remove fullheight to see if it fixes mobile footer

### DIFF
--- a/src/components/Content/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/Content/components/ContentDrawer/ContentDrawer.tsx
@@ -33,7 +33,6 @@ export default function ContentDrawer({
     delta: 250,
   });
   const sizeType = useBreakpointValue({ base: "full", sm: "md" });
-  const fullHeight = useBreakpointValue({ base: true, sm: false });
 
   return (
     <Drawer
@@ -42,7 +41,6 @@ export default function ContentDrawer({
       size={sizeType}
       placement={placement}
       initialFocusRef={refHook}
-      isFullHeight={fullHeight}
       {...rest}
     >
       <DrawerOverlay zIndex={2} />


### PR DESCRIPTION
## Solution
- I still don't know why the mobile drawers don't show the appropriate footer. Might have to update the package as well